### PR TITLE
fix: 当代理了copilot chat + 不使用GPT时；request 的typo 错误所导致的变量未定义

### DIFF
--- a/blueprints/proxy/routes.py
+++ b/blueprints/proxy/routes.py
@@ -90,7 +90,7 @@ async def proxy_copilot_chat_completion():
         res = await proxy_request(new_request, GPT_CHAT_URL, max_retry=max_retry)
     else:
         headers = dict(request.headers)
-        res = await proxy_request(new_request, CHAT_COMPLETION_URL)
+        res = await proxy_request(request, CHAT_COMPLETION_URL)
     return res
 
 


### PR DESCRIPTION
fix: 当代理了copilot chat + 不使用GPT时；request 的typo 错误所导致的变量未定义

err如下：

> Traceback (most recent call last):
  File "/data/copilot_share/.venv/lib/python3.10/site-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/data/copilot_share/.venv/lib/python3.10/site-packages/flask/app.py", line 1486, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/data/copilot_share/.venv/lib/python3.10/site-packages/flask_cors/extension.py", line 176, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/data/copilot_share/.venv/lib/python3.10/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/data/copilot_share/.venv/lib/python3.10/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/data/copilot_share/.venv/lib/python3.10/site-packages/asgiref/sync.py", line 277, in __call__
    return call_result.result()
  File "/usr/local/python3.10/lib/python3.10/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/local/python3.10/lib/python3.10/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/data/copilot_share/.venv/lib/python3.10/site-packages/asgiref/sync.py", line 353, in main_wrap
    result = await self.awaitable(*args, **kwargs)
  File "/data/copilot_share/utils/decorators.py", line 42, in wrapper
    return await fun(*args, **kwargs)
  File "/data/copilot_share/blueprints/proxy/routes.py", line 93, in proxy_copilot_chat_completion
    res = await proxy_request(new_request, CHAT_COMPLETION_URL)
UnboundLocalError: local variable 'new_request' referenced before assignment